### PR TITLE
Change beginRe and endRe to not match inside double quotes

### DIFF
--- a/src/symbolprovider.ts
+++ b/src/symbolprovider.ts
@@ -41,13 +41,13 @@ export class TALDocumentSymbolProvider implements vscode.DocumentSymbolProvider 
      * Match begin/end keywords.
      * These are reserved keywords. They can't be declared as variables.
      * So, simply searching for them is sufficient to determine
-     * where things beging and end.
+     * where things begin and end.
      */
     private beginRe = RegExp(''
-        + /\b(?<!\^)(begin)(?!\^)\b/.source,
+        + /\b(?<!\^)(begin)(?=([^"]*"[^"]*")*[^"]*$)(?!\^)\b/.source,
         'ig');
     private endRe = RegExp(''
-        + /\b(?<!\^)(end)(?!\^)\b/.source,
+        + /\b(?<!\^)(end)(?=([^"]*"[^"]*")*[^"]*$)(?!\^)\b/.source,
         'ig');
 
     /**


### PR DESCRIPTION
Hi, 

Another small change to stop the TAL PROC/SUBPROC map being incorrect by matching BEGIN or END inside a quoted string. In my case a END was inside a quoted string. It stopped the map and noted main was the line after the quoted string containing the END. No further SUBPROCS were in the PROC map even though they existed.

I didn't check other re's though, this is specific to the problem I saw.

Jason.